### PR TITLE
Fix author affiliations to match actual manuscript (arXiv 2408.11876)

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,33 +25,38 @@
         <h1 property="headline">A Foundation Model for Continuous Glucose Monitoring Data</h1>
         <h2 property="alternativeHeadline">GluFormer learns generalizable representations of metabolic health from 10 million glucose measurements</h2>
         <address>
-          <a property="author">Guy Lutsker<sup>1</sup></a>,
-          <a property="author"><strong>Gal Sapir</strong><sup>1</sup></a>,
-          <a property="author">Smadar Shilo<sup>1,2</sup></a>,
-          <a property="author">Jordi Merino<sup>3</sup></a>,
-          <a property="author">Anastasia Godneva<sup>1</sup></a>,
-          <a property="author">Jerry R. Greenfield<sup>4</sup></a>,
-          <a property="author">Dorit Samocha-Bonet<sup>4</sup></a>,
-          <a property="author">Raja Dhir<sup>5</sup></a>,
-          <a property="author">Francisco Gude<sup>6</sup></a>,
-          <a property="author">Shie Mannor<sup>7</sup></a>,
-          <a property="author">Eli Meirom<sup>8</sup></a>,
-          <a property="author">Eric P. Xing<sup>9</sup></a>,
-          <a property="author">Gal Chechik<sup>8,10</sup></a>,
-          <a property="author">Hagai Rossman<sup>1</sup></a>,
-          <a property="author">Eran Segal<sup>1</sup></a>
+          <a property="author">Guy Lutsker<sup>1,2,3</sup></a>,
+          <a property="author"><strong>Gal Sapir</strong><sup>1,4</sup></a>,
+          <a property="author">Smadar Shilo<sup>1,2,5,6</sup></a>,
+          <a property="author">Jordi Merino<sup>7,8,9</sup></a>,
+          <a property="author">Anastasia Godneva<sup>1,2</sup></a>,
+          <a property="author">Jerry R. Greenfield<sup>10,11,12</sup></a>,
+          <a property="author">Dorit Samocha-Bonet<sup>10,11</sup></a>,
+          <a property="author">Raja Dhir<sup>13</sup></a>,
+          <a property="author">Francisco Gude<sup>14,15</sup></a>,
+          <a property="author">Shie Mannor<sup>3</sup></a>,
+          <a property="author">Eli Meirom<sup>3</sup></a>,
+          <a property="author">Gal Chechik<sup>3</sup></a>,
+          <a property="author">Hagai Rossman<sup>4,*</sup></a>,
+          <a property="author">Eran Segal<sup>1,16,*</sup></a>
           <br/>
           <span class="affiliations">
-            <sup>1</sup>Weizmann Institute of Science &nbsp;
-            <sup>2</sup>Sheba Medical Center &nbsp;
-            <sup>3</sup>Novo Nordisk Foundation &nbsp;
-            <sup>4</sup>Garvan Institute &nbsp;
-            <sup>5</sup>Seed Health &nbsp;
-            <sup>6</sup>Santiago de Compostela &nbsp;
-            <sup>7</sup>Technion &nbsp;
-            <sup>8</sup>NVIDIA Research &nbsp;
-            <sup>9</sup>MBZUAI &nbsp;
-            <sup>10</sup>Bar-Ilan University
+            <sup>1</sup>Dept. of Computer Science and Applied Mathematics, Weizmann Institute of Science &nbsp;
+            <sup>2</sup>Dept. of Molecular Cell Biology, Weizmann Institute of Science &nbsp;
+            <sup>3</sup>NVIDIA, Tel Aviv &nbsp;
+            <sup>4</sup>Pheno.AI, Tel Aviv &nbsp;
+            <sup>5</sup>Faculty of Medical and Health Sciences, Tel Aviv University &nbsp;
+            <sup>6</sup>Schneider Children's Medical Center of Israel &nbsp;
+            <sup>7</sup>Novo Nordisk Foundation, University of Copenhagen &nbsp;
+            <sup>8</sup>Massachusetts General Hospital, Boston &nbsp;
+            <sup>9</sup>Center for Genomic Medicine, MGH &nbsp;
+            <sup>10</sup>Garvan Institute of Medical Research, Sydney &nbsp;
+            <sup>11</sup>St Vincent's Clinical School, UNSW, Sydney &nbsp;
+            <sup>12</sup>St Vincent's Hospital, Sydney &nbsp;
+            <sup>13</sup>SIAF, University of Zurich &nbsp;
+            <sup>14</sup>University of Santiago de Compostela &nbsp;
+            <sup>15</sup>Concepción Arenal Primary Care Center, Santiago de Compostela &nbsp;
+            <sup>16</sup>MBZUAI, Abu Dhabi
           </span>
         </address>
         <span class="publication-info">


### PR DESCRIPTION
Corrected all 16 affiliations and author superscripts to match the published paper. Removed Eric P. Xing (not an author). Fixed institutions: e.g. Seed Health → SIAF/Univ. Zurich, Sheba Medical Center → Schneider Children's, added Pheno.AI, MBZUAI, etc.

https://claude.ai/code/session_018jbwZ1aQ4e8Jz7dSHu68pG